### PR TITLE
updated text in write off step modal

### DIFF
--- a/src/components/QuestionnairesStepper.tsx
+++ b/src/components/QuestionnairesStepper.tsx
@@ -128,8 +128,8 @@ export default function QuestionnairesStepper({
               {step?.question}
             </h2>
             <p className="text-gray-600 text-center text-[var(--500,#71717A)] font-inter text-[12px] font-medium leading-normal">
-              This info allows Keeper to suggest tax savings. Select all that
-              apply.
+              This information allows Skattepluss to suggest tax savings. Select
+              all that apply.
             </p>
           </div>
         </div>


### PR DESCRIPTION
Replaced “Keeper” with “Skattepluss” in the sentence: “This information
allows Skattepluss to suggest tax savings. Select all that apply.”